### PR TITLE
fix: adding oauth validations to restrict unauthorised actions or integrations

### DIFF
--- a/app/api/oauth/authorize/route.ts
+++ b/app/api/oauth/authorize/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCredentials, parseFirebaseConfig } from "@/lib/credentials";
 import { verifyIdToken } from "@/lib/auth";
 import { redis } from "@/lib/redis";
+import { isAllowedOAuthRedirect } from "@/lib/oauth-clients";
 import crypto from "crypto";
 
 export const dynamic = "force-dynamic";
@@ -15,6 +16,10 @@ export async function GET(req: NextRequest) {
 
   if (!clientId || !redirectUri || !state) {
     return new NextResponse("Missing required OAuth 2.0 query parameters (client_id, redirect_uri, state).", { status: 400 });
+  }
+
+  if (!isAllowedOAuthRedirect(clientId, redirectUri)) {
+    return new NextResponse("Unrecognized client_id/redirect_uri — this client is not registered.", { status: 400 });
   }
 
   const creds = await getCredentials(req);
@@ -304,6 +309,10 @@ export async function POST(req: NextRequest) {
 
     if (!idToken || !refreshToken || !clientId || !redirectUri || !state) {
       return NextResponse.json({ error: "Missing required parameters." }, { status: 400 });
+    }
+
+    if (!isAllowedOAuthRedirect(clientId, redirectUri)) {
+      return NextResponse.json({ error: "Unrecognized client_id/redirect_uri — this client is not registered." }, { status: 400 });
     }
 
     // 1. Verify user identity token

--- a/lib/oauth-clients.ts
+++ b/lib/oauth-clients.ts
@@ -1,0 +1,49 @@
+// Registered OAuth clients allowed to complete the /api/oauth/authorize flow
+// and receive a user's Firebase refresh token. Without this, any client_id/
+// redirect_uri pair was accepted verbatim and the auth code (which resolves
+// to the user's permanent refresh token) was redirected wherever the caller
+// asked — a crafted link could exfiltrate any authorizing user's account.
+//
+// OAUTH_ALLOWED_CLIENTS is a JSON array of either:
+//   { "clientId": "monolith-dashboard", "redirectUri": "https://exact/match/callback" }
+//   { "clientId": "chatgpt", "redirectUriPrefix": "https://chatgpt.com/aip/" }
+// Prefix entries exist for platforms like ChatGPT Actions, whose callback
+// URL embeds a per-GPT id we don't control or know ahead of time
+// (https://chatgpt.com/aip/{g-id}/oauth/callback) — the prefix still pins
+// the redirect to that platform's own domain.
+interface OAuthClientEntry {
+  clientId: string;
+  redirectUri?: string;
+  redirectUriPrefix?: string;
+}
+
+let cachedEntries: OAuthClientEntry[] | null = null;
+
+function loadEntries(): OAuthClientEntry[] {
+  if (cachedEntries) return cachedEntries;
+
+  const raw = process.env.OAUTH_ALLOWED_CLIENTS;
+  if (!raw) {
+    cachedEntries = [];
+    return cachedEntries;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    cachedEntries = Array.isArray(parsed) ? parsed : [];
+  } catch {
+    console.error("OAUTH_ALLOWED_CLIENTS is not valid JSON — no OAuth clients will be permitted.");
+    cachedEntries = [];
+  }
+
+  return cachedEntries;
+}
+
+export function isAllowedOAuthRedirect(clientId: string, redirectUri: string): boolean {
+  return loadEntries().some((entry) => {
+    if (entry.clientId !== clientId) return false;
+    if (entry.redirectUri) return entry.redirectUri === redirectUri;
+    if (entry.redirectUriPrefix) return redirectUri.startsWith(entry.redirectUriPrefix);
+    return false;
+  });
+}


### PR DESCRIPTION
Previously any redirect_uri was accepted and redirected to verbatim once a user authorized, so a crafted link could exfiltrate that user's permanent Firebase refresh token to an attacker-controlled URL. Adds an explicit allowlist (OAUTH_ALLOWED_CLIENTS) checked before rendering the consent screen and before issuing the auth code.

## Description
Please describe the changes proposed in this Pull Request, including the motivation and context.

## Related Issues
Closes #[issue_number]

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / Documentation update

## Checklist
- [ ] I have verified that `npm run lint` passes locally without any errors.
- [ ] I have verified that `npm run build` compiles successfully.
- [ ] I have added/updated comments on complex or new logic.
